### PR TITLE
Fix domain's docker image + docker-compose uses pre-built images

### DIFF
--- a/build_docker_images.sh
+++ b/build_docker_images.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Author : Rafael Direito (rdireito@av.it.pt)
+# Copyright (c) Instituto de Telecomunicações  - Aveiro
+# Date: November 9th, 2021
+
+while test $# -gt 0
+do
+    case "$1" in
+        all) 
+            echo "Building all images..."
+            docker build ./catalogue/slicer-catalogue/db/primary -t netor/mongo1 --no-cache	
+            docker build ./catalogue/slicer-catalogue/db/secondary1 -t netor/mongo2 --no-cache	
+            docker build ./catalogue/slicer-catalogue/db/secondary2 -t netor/mongo3 --no-cache	
+            docker build ./coordinator -t netor/coordinator --no-cache		
+            docker build ./manager -t netor/manager --no-cache	
+            docker build ./placement -t netor/placement --no-cache	
+            docker build ./tenant -t netor/tenant --no-cache	
+            docker build ./catalogue/slicer-catalogue -t netor/catalogue --no-cache	
+            docker build ./catalogue/portal -t netor/portal --no-cache	
+            docker build ./domain -t netor/domain --no-cache \
+                --build-arg PYTHON3_OSM_IM_URL='https://artifactory-osm.etsi.org/artifactory/osm-IM/v11.0/2/pool/IM/python3-osm-im_9.0.0.post19+g1ab5b68-1_all.deb' \
+                --build-arg PYTHON3_OSMCLIENT_URL='https://artifactory-osm.etsi.org/artifactory/osm-osmclient/v10.0/14/pool/osmclient/python3-osmclient_10.0.3+gc0a69f8-1_all.deb'
+            ;;
+        mongo1) echo "Building the mongo1's image..."
+            docker build ./catalogue/slicer-catalogue/db/primary -t netor/mongo1 --no-cache	
+            ;;
+        mongo2) echo "Building the mongo2's image..."
+            docker build ./catalogue/slicer-catalogue/db/secondary1 -t netor/mongo2 --no-cache	
+            ;;
+        mongo3) echo "Building the mongo3's image..."
+            docker build ./catalogue/slicer-catalogue/db/secondary2 -t netor/mongo3 --no-cache	
+            ;;
+        coordinator) echo "Building the coordinator's image..."
+            docker build ./coordinator -t netor/coordinator --no-cache	
+            ;;
+        domain) echo "Building the domain's image..."
+            docker build ./domain -t netor/domain --no-cache \
+                --build-arg PYTHON3_OSM_IM_URL='https://artifactory-osm.etsi.org/artifactory/osm-IM/v11.0/2/pool/IM/python3-osm-im_9.0.0.post19+g1ab5b68-1_all.deb' \
+                --build-arg PYTHON3_OSMCLIENT_URL='https://artifactory-osm.etsi.org/artifactory/osm-osmclient/v10.0/14/pool/osmclient/python3-osmclient_10.0.3+gc0a69f8-1_all.deb'
+            ;;
+        manager) echo "Building the manager's image..."
+            docker build ./manager -t netor/manager --no-cache	
+            ;;
+        placement) echo "Building the placement's image..."
+            docker build ./placement -t netor/placement --no-cache	
+            ;;
+        tenant) echo "Building the tenant's image..."
+            docker build ./tenant -t netor/tenant --no-cache	
+            ;;
+        catalogue) echo "Building the placement's image..."
+            docker build ./catalogue/slicer-catalogue -t netor/catalogue --no-cache	
+            ;;
+        portal) echo "Building the portal's image..."
+            docker build ./catalogue/portal -t netor/portal --no-cache	
+            ;; 
+    esac
+    shift
+done
+
+exit 0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
       - REDIS_REPLICATION_MODE=master
 
   mongo1:
-    build: ./catalogue/slicer-catalogue/db/primary
+    image: netor/mongo1
     ports:
       - 27017:27017
     restart: always
@@ -59,7 +59,7 @@ services:
   mongo2:
     depends_on:
       - mongo1
-    build: ./catalogue/slicer-catalogue/db/secondary1
+    image: netor/mongo2
     ports:
       - 27012:27017
     restart: always
@@ -74,7 +74,7 @@ services:
   mongo3:
     depends_on:
       - mongo1
-    build: ./catalogue/slicer-catalogue/db/secondary2
+    image: netor/mongo3
     ports:
       - 27013:27017
     restart: always
@@ -95,7 +95,7 @@ services:
       - 443:443
 
   netor_coordinator:
-    build: ./coordinator
+    image: netor/coordinator
     restart: always
     depends_on:
       - postgres
@@ -115,7 +115,7 @@ services:
       ENVIRONMENT: prod
 
   netor_domain:
-    build: ./domain
+    image: netor/domain
     restart: always
     depends_on:
       - postgres
@@ -135,7 +135,7 @@ services:
       ENVIRONMENT: prod
 
   netor_manager:
-    build: ./manager
+    image: netor/manager
     restart: always
     depends_on:
       - redis
@@ -151,7 +151,7 @@ services:
       ENVIRONMENT: prod
 
   netor_placement:
-    build: ./placement
+    image: netor/placement
     restart: always
     depends_on:
       - redis
@@ -164,7 +164,7 @@ services:
       ENVIRONMENT: prod
 
   netor_tenant:
-    build: ./tenant
+    image: netor/tenant
     restart: always
     depends_on:
       - postgres
@@ -183,7 +183,7 @@ services:
       ENVIRONMENT: prod
 
   netor_catalogue:
-    build: ./catalogue/slicer-catalogue
+    image: netor/catalogue
     restart: always
     ports:
       - 5010:5010
@@ -205,7 +205,7 @@ services:
       ENVIRONMENT: prod
 
   # netor_portal:
-  #   build: ./portal
+  #   image: netor/portal
   #   restart: always
   #   ports:
   #     - '4200:4200'

--- a/domain/Dockerfile
+++ b/domain/Dockerfile
@@ -1,10 +1,29 @@
 FROM ubuntu:18.04
+
 COPY . .
+
 RUN apt-get update
-RUN apt-get install -y python3.8
-RUN apt-get install -y python3-pip
-RUN apt-get install -y libpq-dev
+RUN apt-get -y install \
+    python3.8 \
+    python3-pip \
+    libpq-dev \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    curl
+
+ARG PYTHON3_OSMCLIENT_URL
+ARG PYTHON3_OSM_IM_URL
+
+RUN curl $PYTHON3_OSMCLIENT_URL -o osmclient.deb
+RUN dpkg -i ./osmclient.deb
+
+RUN curl $PYTHON3_OSM_IM_URL -o osm_im.deb
+RUN dpkg -i ./osm_im.deb
+
+
 RUN pip3 install -r requirements.txt
+
 RUN chmod +x installDrivers.sh
 RUN ./installDrivers.sh
+
 CMD python3 main.py

--- a/domain/requirements.txt
+++ b/domain/requirements.txt
@@ -10,4 +10,5 @@ verboselogs
 importlib-metadata
 jsonschema
 flask-cors
+pycurl==7.44.1
 packaging==21.2

--- a/domain/requirements.txt
+++ b/domain/requirements.txt
@@ -10,3 +10,4 @@ verboselogs
 importlib-metadata
 jsonschema
 flask-cors
+packaging==21.2


### PR DESCRIPTION
- Fixed the netor/domain image:
  - Added the osm-im and osm-client packages
  - Updated the domain/requirements.txt
  - Several updates in domain/Dockerfile
- Created a script to build the netor docker images (`build_docker_images.sh`)  
- Changed the docker-compose to use pre-built images, instead of building them on the fly